### PR TITLE
Fixed `getOrCreate` for String keyPaths

### DIFF
--- a/EZCoreData.podspec
+++ b/EZCoreData.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'EZCoreData'
-  s.version          = '0.6.2'
+  s.version          = '0.6.3'
   s.summary          = 'A great helper for core data if you use iOS 10.0+'
 
 # This description is used to generate tags and improve search results.

--- a/EZCoreData/Classes/NSManagedObject+Read.swift
+++ b/EZCoreData/Classes/NSManagedObject+Read.swift
@@ -66,7 +66,16 @@ extension NSFetchRequestResult where Self: NSManagedObject {
     static public func readFirst(attribute: String,
                                  value: String,
                                  context: NSManagedObjectContext = EZCoreData.mainThreadContext) throws -> Self? {
-        let predicate = NSPredicate(format: "\(attribute) == \(value)")
+        let predicate = comparisionPredicate(attribute: attribute, value: value)
+        let fetchRequest = readFirstFetchRequest(predicate, context: context)
+        return try context.fetch(fetchRequest).first
+    }
+
+    /// SYNC read first result with the given `attribute` and `value`
+    static public func readFirst(attribute: String,
+                                 value: Int,
+                                 context: NSManagedObjectContext = EZCoreData.mainThreadContext) throws -> Self? {
+        let predicate = comparisionPredicate(attribute: attribute, value: value)
         let fetchRequest = readFirstFetchRequest(predicate, context: context)
         return try context.fetch(fetchRequest).first
     }
@@ -125,7 +134,7 @@ extension NSFetchRequestResult where Self: NSManagedObject {
                                           value: String,
                                           sortDescriptors: [NSSortDescriptor]? = nil,
                                           context: NSManagedObjectContext = EZCoreData.mainThreadContext)
-        throws -> [Self] {
+    throws -> [Self] {
         // Prepare the request
         let fetchRequest = readAllByAttributeFetchRequest(attribute,
                                                           value: value,

--- a/Example/Tests/TestEntityCreation.swift
+++ b/Example/Tests/TestEntityCreation.swift
@@ -16,7 +16,7 @@ class TestEntityCreation: EZTestCase {
         do {
             // Test Count and Save methods
             let initialCount = try Article.count(context: context)
-            _ = Article.getOrCreate(attribute: "id", value: "1234", context: context)
+            _ = Article.getOrCreate(attribute: "id", value: 1234, context: context)
             try context.save()
             let countPP = try Article.count(context: context)
             XCTAssertEqual(initialCount + 1, countPP)

--- a/Example/Tests/TestEntityDeletion.swift
+++ b/Example/Tests/TestEntityDeletion.swift
@@ -17,7 +17,7 @@ class TestEntityDeletion: EZTestCase {
             // Test Count and Save methods
             let initialCount = try Article.count(context: context)
             print(initialCount)
-            let article = Article.getOrCreate(attribute: "id", value: "1234", context: context)
+            let article = Article.getOrCreate(attribute: "id", value: 1234, context: context)
             try context.save()
             let countPP = try Article.count(context: context)
             XCTAssertEqual(initialCount + 1, countPP)

--- a/Example/Tests/TestEntityRead.swift
+++ b/Example/Tests/TestEntityRead.swift
@@ -117,10 +117,13 @@ class TestEntityRead: EZTestCase {
 
     func testReadFirstWithAttribute() {
         do {
-            let randId = Int16.random(in: 1 ... 6)
-            let randIdString = String(describing: randId)
-            let article = try Article.readFirst(attribute: "id", value: randIdString, context: context)
-            XCTAssertEqual(article!.id, randId)
+            let randId = Int.random(in: 1 ... 6)
+//            let article = try Article.readFirst(attribute: "id", value: randId, context: context)
+            if let article = try Article.readFirst(attribute: "id", value: randId, context: context) {
+                XCTAssertEqual(article.id, Int16(randId))
+            } else {
+                XCTAssertTrue(false)
+            }
         } catch let error {
             print(error.localizedDescription)
         }


### PR DESCRIPTION
FIxed issue of calling getOrCreate or import methods using a String as a key (instead of an integer)